### PR TITLE
make clones faster on v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ lazy_static = "1.4.0"
 rand_xorshift = "0.2.0"
 rand = "0.7.2"
 sgf-parser = "2.3.0"
+arrayvec = "0.5.1"
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/src/pieces/go_string.rs
+++ b/src/pieces/go_string.rs
@@ -38,14 +38,19 @@ impl GoString {
     }
 
     #[inline]
+    pub fn contains_liberties(&self, point: Point) -> bool {
+        self.liberties.contains(&point)
+    }
+
+    #[inline]
     pub fn remove_liberty(&mut self, point: Point) {
-        debug_assert!(self.liberties.contains(&point));
+        // debug_assert!(self.liberties.contains(&point));
         self.liberties.remove(&point);
     }
 
     #[inline]
     pub fn add_liberty(&mut self, point: Point) {
-        //debug_assert!(!self.liberties.contains(&point));
+        // debug_assert!(!self.liberties.contains(&point));
         self.liberties.insert(point);
     }
 

--- a/src/pieces/territory.rs
+++ b/src/pieces/territory.rs
@@ -16,7 +16,7 @@ impl Goban {
     ) -> impl Iterator<Item=GoStringPtr> + '_ {
         self.go_strings()
             .values()
-            .filter(move |go_str| go_str.borrow().is_dead() && go_str.borrow().color == color)
+            .filter(move |go_str| go_str.is_dead() && go_str.color == color)
             .map(ToOwned::to_owned)
     }
 

--- a/src/pieces/territory.rs
+++ b/src/pieces/territory.rs
@@ -15,7 +15,8 @@ impl Goban {
         color: Color,
     ) -> impl Iterator<Item=GoStringPtr> + '_ {
         self.go_strings()
-            .values()
+            .iter()
+            .filter_map(|x| x.as_ref())
             .filter(move |go_str| go_str.is_dead() && go_str.color == color)
             .map(ToOwned::to_owned)
     }

--- a/src/pieces/util.rs
+++ b/src/pieces/util.rs
@@ -1,6 +1,7 @@
 //! Module with the logic for calculating coordinates.
 
 pub mod coord {
+    use arrayvec::ArrayVec;
 
     /// Defining the policy for the colums.
     pub type Point = (usize, usize);
@@ -20,23 +21,23 @@ pub mod coord {
     }
 
     #[inline]
-    pub fn neighbors_points((x1, x2): Point) -> Vec<Point> {
-        vec![
+    pub fn neighbors_points((x1, x2): Point) -> ArrayVec<[Point; 4]> {
+        ArrayVec::from([
             (x1.wrapping_add(1), x2),
             (x1.wrapping_sub(1), x2),
             (x1, x2.wrapping_add(1)),
             (x1, x2.wrapping_sub(1)),
-        ]
+        ])
     }
 
     #[inline]
-    pub fn corner_coords((x1, x2): Point) -> Vec<Point> {
-        vec![
+    pub fn corner_coords((x1, x2): Point) -> ArrayVec<[Point; 4]> {
+        ArrayVec::from([
             (x1.wrapping_add(1), x2.wrapping_add(1)),
             (x1.wrapping_sub(1), x2.wrapping_sub(1)),
             (x1.wrapping_add(1), x2.wrapping_sub(1)),
             (x1.wrapping_sub(1), x2.wrapping_add(1)),
-        ]
+        ])
     }
 
     impl CoordUtil {

--- a/src/rules/game.rs
+++ b/src/rules/game.rs
@@ -42,7 +42,7 @@ pub struct Game {
     handicap: u8,
 
     #[get = "pub"]
-    plays: Vec<Goban>,
+    plays: Vec<u64>,
 
     hashes: HashSet<u64>,
 }
@@ -150,8 +150,9 @@ impl Game {
                 self
             }
             Move::Play(x, y) => {
-                self.plays.push(self.goban.clone());
-                self.hashes.insert(self.goban.hash());
+                let hash = self.goban.hash();
+                self.plays.push(hash);
+                self.hashes.insert(hash);
                 self.goban.push((x, y), self.turn.get_stone_color());
                 self.prisoners = self.remove_captured_stones();
                 self.turn = !self.turn;
@@ -271,8 +272,7 @@ impl Game {
         if self.plays.len() <= 2 || !self.will_capture(stone.coordinates) {
             false
         } else {
-            self.play_for_verification(stone.coordinates) == self.plays[self.plays.len() -
-                1].hash()
+            self.play_for_verification(stone.coordinates) == self.plays[self.plays.len() - 1]
         }
     }
 

--- a/src/rules/game.rs
+++ b/src/rules/game.rs
@@ -235,11 +235,11 @@ impl Game {
         } else {
             let mut friendly_strings = vec![];
             for neighbor_go_string in self.goban.get_neighbors_strings(stone.coordinates) {
-                if neighbor_go_string.borrow().color == stone.color {
+                if neighbor_go_string.color == stone.color {
                     friendly_strings.push(neighbor_go_string)
                 } else {
                     // capture move so not suicide
-                    if neighbor_go_string.borrow().number_of_liberties() == 1 {
+                    if neighbor_go_string.number_of_liberties() == 1 {
                         return false;
                     }
                 }
@@ -248,7 +248,7 @@ impl Game {
             // it's self capture
             friendly_strings
                 .into_iter()
-                .all(|go_str_ptr| go_str_ptr.borrow().number_of_liberties() == 1)
+                .all(|go_str_ptr| go_str_ptr.number_of_liberties() == 1)
         }
     }
 
@@ -259,9 +259,9 @@ impl Game {
     pub fn will_capture(&self, point: Point) -> bool {
         self.goban
             .get_neighbors_strings(point)
-            .filter(|go_str_ptr| go_str_ptr.borrow().color != self.turn.get_stone_color())
+            .filter(|go_str_ptr| go_str_ptr.color != self.turn.get_stone_color())
             // if an enemy string has only liberty it's a capture move
-            .any(|go_str_ptr| go_str_ptr.borrow().number_of_liberties() == 1)
+            .any(|go_str_ptr| go_str_ptr.number_of_liberties() == 1)
     }
 
     ///
@@ -333,7 +333,7 @@ impl Game {
             .collect::<HashSet<_>>();
         for group_of_stones in string_without_liberties
             {
-                number_of_stones_captured += group_of_stones.borrow().stones().len() as u32;
+                number_of_stones_captured += group_of_stones.stones().len() as u32;
                 self.goban.remove_string(group_of_stones);
             }
         number_of_stones_captured

--- a/src/rules/game.rs
+++ b/src/rules/game.rs
@@ -233,10 +233,11 @@ impl Game {
         if self.goban.has_liberties(stone) {
             false
         } else {
-            let mut friendly_strings = vec![];
             for neighbor_go_string in self.goban.get_neighbors_strings(stone.coordinates) {
                 if neighbor_go_string.color == stone.color {
-                    friendly_strings.push(neighbor_go_string)
+                    if neighbor_go_string.number_of_liberties() != 1 {
+                        return false;
+                    }
                 } else {
                     // capture move so not suicide
                     if neighbor_go_string.number_of_liberties() == 1 {
@@ -244,11 +245,7 @@ impl Game {
                     }
                 }
             }
-            // If all of the same color go strings have only one liberty then
-            // it's self capture
-            friendly_strings
-                .into_iter()
-                .all(|go_str_ptr| go_str_ptr.number_of_liberties() == 1)
+            true
         }
     }
 


### PR DESCRIPTION
Thanks for the interesting read! Both the blog post and the code! You asked me to look at the performance of the `v2_dev` branch.

I checked out the `v2_dev` branch and hit it with a profiler. Looks like the benchmark spend most of its time in [`self.clone()`](https://github.com/SamBlaise/goban/blob/v2_dev/src/rules/game.rs#L131), and that function spend most of its time in `plays.clone()`. Because `plays` stores every previous game state checking for legal moves for the last move of the game needs to call [`Goban.clone()`](https://github.com/SamBlaise/goban/blob/v2_dev/src/pieces/goban.rs#L385) approximately 300 times. Over all `Goban.clone()` is called some 45000 times to play out one game. So the first commit changes `plays` to store only the hash witch is much smaller and easier to clone. Now to play a game `Goban.clone()` is called more like 300 times. On my computer this `game_play` benchmark was approximately 16sec/game and after this first commit is 705 ms!

Now looking with the profiler the benchmark was spending most of it time on the [`go_strings.insert`](https://github.com/SamBlaise/goban/blob/v2_dev/src/pieces/goban.rs#L392) call. By a similar argument to above... On the 300th move there are 300ed `point`s to insert, so `insert` is called some 45000 times. However most of this work is wasted as the new `go_str` will continue to be the same as the old one. We only push one stone at a time after all. The second commit changes the code to only do a deep clone when we actually need to change something about the `string`. This requires some more calls to `update_map_indexes` to ensure that all points in that string are updated to point to the new modified one. On my computer this `game_play` benchmark after this second commit is 51 ms!

That is what I have time for today. I think the TLDR is (as always profile before optimizing, but) avoid unnecessary clones and if they are necessary then make sure clone is fast.