### PR TITLE
Remove game.clone by reducing the use of &mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ thread-safe = []
 
 [dependencies]
 arrayvec = "0.5.1"
-sloth = "0.2.0"
 by_address = "1.0.4"
 getset = "0.0.9"
 lazy_static = "1.4.0"

--- a/benches/perft.rs
+++ b/benches/perft.rs
@@ -51,7 +51,7 @@ pub fn play_game() {
 
 pub fn perft_bench(_c: &mut Criterion) {
     let g = Game::new(GobanSizes::Nineteen, Japanese);
-    let deep = 4;
+    let deep = 2;
     let criterion: Criterion = Default::default();
     criterion.sample_size(10).bench_function_over_inputs(
         "perft",
@@ -60,7 +60,7 @@ pub fn perft_bench(_c: &mut Criterion) {
                 perft(&g, *size);
             })
         },
-        (0..deep).into_iter(),
+        (1..=deep).into_iter(),
     );
 }
 

--- a/benches/perft.rs
+++ b/benches/perft.rs
@@ -28,6 +28,25 @@ pub fn perft(pos: &Game, depth: u8) -> u64 {
     }
 }
 
+pub fn fast_play_random(state: &Game) -> Move {
+    for l in state.legals_shuffle(&mut thread_rng()) {
+        if !state
+            .goban()
+            .is_point_an_eye(l, state.turn().get_stone_color())
+        {
+            return l.into();
+        }
+    }
+    Move::Pass
+}
+
+pub fn fast_play_game() {
+    let mut g = Game::new(GobanSizes::Nineteen, Chinese);
+    while !g.is_over() {
+        g.play(fast_play_random(&g));
+    }
+}
+
 pub fn play_random(state: &Game) -> Move {
     let mut legals = state.legals().collect::<Vec<_>>();
     legals.shuffle(&mut thread_rng());
@@ -68,7 +87,8 @@ pub fn game_play_bench(_c: &mut Criterion) {
     let criterion: Criterion = Default::default();
     criterion
         .sample_size(100)
-        .bench_function("game_play", |b| b.iter(|| play_game()));
+        .bench_function("game_play", |b| b.iter(|| play_game()))
+        .bench_function("fast_play_game", |b| b.iter(|| fast_play_game()));
 }
 
 criterion_group!(benches, game_play_bench);

--- a/src/pieces/goban.rs
+++ b/src/pieces/goban.rs
@@ -364,6 +364,22 @@ impl Goban {
             self.go_strings[self.coord_util.to(point)] = Option::None;
         }
     }
+
+    ///
+    /// Removes the dead stones from the goban by specifying a color stone.
+    /// Returns the number of stones removed from the goban.
+    ///
+    pub fn remove_captured_stones_turn(&mut self, color: Color) -> u32 {
+        let mut number_of_stones_captured = 0u32;
+        let string_without_liberties = self
+            .get_strings_of_stones_without_liberties_wth_color(color)
+            .collect::<HashSet<_>>();
+        for group_of_stones in string_without_liberties {
+            number_of_stones_captured += group_of_stones.stones().len() as u32;
+            self.remove_string(group_of_stones);
+        }
+        number_of_stones_captured
+    }
 }
 
 impl Display for Goban {

--- a/src/pieces/goban.rs
+++ b/src/pieces/goban.rs
@@ -193,6 +193,14 @@ impl Goban {
     }
 
     #[inline]
+    pub fn get_empty_points(&self) -> impl Iterator<Item=Point> + '_ {
+        self.go_strings.iter()
+            .enumerate()
+            .filter(|(_, ptr)| ptr.is_none())
+            .map(move |(index, _)| self.coord_util.from(index))
+    }
+
+    #[inline]
     pub fn get_points_by_color(&self, color: Color) -> impl Iterator<Item = Point> + '_ {
         self.get_points()
             .filter(move |&point| self.get_stone(point) == color)

--- a/src/rules/game.rs
+++ b/src/rules/game.rs
@@ -126,7 +126,7 @@ impl Game {
     ///
     #[inline]
     fn pseudo_legals(&self) -> impl Iterator<Item = Point> + '_ {
-        self.goban.get_points_by_color(Color::None)
+        self.goban.get_empty_points()
     }
 
     ///
@@ -135,7 +135,7 @@ impl Game {
     #[inline]
     fn pseudo_legals_shuffle(&self, rng: &mut impl rand::Rng) -> Vec<Point> {
         use rand::prelude::SliceRandom;
-        let mut legals = self.goban.get_points_by_color(Color::None).collect::<Vec<_>>();
+        let mut legals = self.goban.get_empty_points().collect::<Vec<_>>();
         legals.shuffle(rng);
         legals
     }

--- a/src/rules/game.rs
+++ b/src/rules/game.rs
@@ -130,12 +130,39 @@ impl Game {
     }
 
     ///
+    /// Generate all moves on all intersections.
+    ///
+    #[inline]
+    fn pseudo_legals_shuffle(&self, rng: &mut impl rand::Rng) -> Vec<Point> {
+        use rand::prelude::SliceRandom;
+        let mut legals = self.goban.get_points_by_color(Color::None).collect::<Vec<_>>();
+        legals.shuffle(rng);
+        legals
+    }
+
+    ///
     /// Returns a list with legals moves,
     /// In the list will appear suicides moves, and ko moves.
     ///
     #[inline]
     pub fn legals(&self) -> impl Iterator<Item = Point> + '_ {
         self.pseudo_legals()
+            .map(move |s| Stone {
+                color: self.turn.get_stone_color(),
+                coordinates: s,
+            })
+            .filter(move |&s| self.rule.move_validation(&self, s).is_none())
+            .map(|s| s.coordinates)
+    }
+
+    ///
+    /// Returns a list with legals moves,
+    /// In the list will appear suicides moves, and ko moves.
+    ///
+    #[inline]
+    pub fn legals_shuffle(&self, rng: &mut impl rand::Rng) -> impl Iterator<Item=Point> + '_ {
+        self.pseudo_legals_shuffle(rng)
+            .into_iter()
             .map(move |s| Stone {
                 color: self.turn.get_stone_color(),
                 coordinates: s,

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -145,7 +145,7 @@ impl Rule {
     ///
     /// Specify the constraints in the move validation by rule.
     ///
-    pub fn move_validation(self, game: &mut Game, stone: Stone) -> Option<PlayError> {
+    pub fn move_validation(self, game: &Game, stone: Stone) -> Option<PlayError> {
         match self {
             Rule::Japanese => {
                 if game.is_suicide(stone) {

--- a/src/rules/sgf_bridge.rs
+++ b/src/rules/sgf_bridge.rs
@@ -1,7 +1,7 @@
+use crate::pieces::util::coord::Point;
 use crate::rules::game::{Game, GameBuilder};
 use crate::rules::{EndGame, Move, Player};
 use sgf_parser::{Action, Color, Outcome, SgfToken};
-use crate::pieces::util::coord::Point;
 
 impl Game {
     pub fn from_sgf(sgf_str: &str) -> Result<Self, String> {


### PR DESCRIPTION
In #1 we found that `self.clone()` was taking most of the time. #1 dealt with that by finding ways to make the clone faster. This deals with it by removing the `&mut` so that it is no longer necessary. This should make a big difference to performance when the `history` feature is on.

The next commit adds a new benchmark. The existing one finds all the valid moves then shuffle them and plays the first. This spends a lot of time in `move_validation` for moves that are not taken. The new benchmark shuffles the available spaces then does the validation. The new one is a much faster way to get to the end of the game. But it is mostly by changing the benchmark, so I left the old one as is.

The last commit does a small optimization. Getting the color of a point that has been played means getting the `GoString` out of the heap. This code is hot enough that the cache miss is slowing us down. Sometimes we are looking for empty points, so we don't even care what the color is, so if we don't ask we go faster.